### PR TITLE
Add config option for requiring damage for rebel

### DIFF
--- a/src/Jail.cs
+++ b/src/Jail.cs
@@ -112,6 +112,9 @@ public class JailConfig : BasePluginConfig
 
     [JsonPropertyName("lr_count")]
     public uint lr_count { get; set; } = 2;
+
+    [JsonPropertyName("rebel_requirehit")]
+    public bool rebel_requirehit { get; set; } = false;
 }
 
 // main plugin file, controls central hooking

--- a/src/Warden/JailPlayer.cs
+++ b/src/Warden/JailPlayer.cs
@@ -84,6 +84,8 @@ public class JailPlayer
         // ignore weapons players are meant to have
         if(!weapon.Contains("knife") && !weapon.Contains("c4"))
         {
+            if(config.rebel_requirehit)
+                return;
             set_rebel(player);
         }
     }


### PR DESCRIPTION
Our server prefers T's have to HIT (deal damage) CT's to be marked red, rather than simply firing a weapon. This MR strides to add support for that.