### PR TITLE
Add logs system

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -50,6 +50,7 @@
 
     "logs.ct": "CT",
     "logs.t": "T",
+    "logs.logs_cmd": "logs",
 
     "role.warden": "Warden",
     "role.guard": "Guard",

--- a/lang/en.json
+++ b/lang/en.json
@@ -64,6 +64,7 @@
     "logs.format.kill": "{0} ({1}) killed {2} ({3})",
     "logs.format.kill_self": "The world killed {0} ({1})",
     "logs.format.button": "{0} ({1}) pressed button {2}->{3}",
+    "logs.format.grenade": "{0} ({1}) threw a {2}",
 
     "mute.thirty": "All t's are muted for the first 30 seconds",
     "mute.speak_quietly": "T's may now speak quietly",

--- a/lang/en.json
+++ b/lang/en.json
@@ -59,11 +59,11 @@
     "role.spectator": "Spectator",
     "role.unknown": "Unknown",
 
-    "logs.format.damage": "{0} [{1}] damaged {2} [{3}] for {4} damage",
-    "logs.format.damage_self": "The world damaged {0} [{1}] for {2} damage",
-    "logs.format.kill": "{0} [{1}] killed {2} [{3}]",
-    "logs.format.kill_self": "The world killed {0} [{1}]",
-    "logs.format.button": "{0} [{1}] pressed button {2}->{3}",
+    "logs.format.damage": "{0} ({1}) damaged {2} ({3}) for {4} damage",
+    "logs.format.damage_self": "The world damaged {0} ({1}) for {2} damage",
+    "logs.format.kill": "{0} ({1}) killed {2} ({3})",
+    "logs.format.kill_self": "The world killed {0} ({1})",
+    "logs.format.button": "{0} ({1}) pressed button {2}->{3}",
 
     "mute.thirty": "All t's are muted for the first 30 seconds",
     "mute.speak_quietly": "T's may now speak quietly",

--- a/lang/en.json
+++ b/lang/en.json
@@ -48,6 +48,21 @@
     "warden.sd_cmd": "wsd",
     "warden.sd_ff_cmd": "wsd_ff",
 
+    "logs.ct": "CT",
+    "logs.t": "T",
+
+    "role.warden": "Warden",
+    "role.guard": "Guard",
+    "role.prisoner": "Prisoner",
+    "role.rebel": "Rebel",
+    "role.spectator": "Spectator",
+    "role.unknown": "Unknown",
+
+    "logs.format.damage": "{0} [{1}] damaged {2} [{3}] for {4} damage",
+    "logs.format.damage_self": "The world damaged {0} [{1}] for {2} damage",
+    "logs.format.kill": "{0} [{1}] killed {2} [{3}]",
+    "logs.format.kill_self": "The world killed {0} [{1}]",
+    "logs.format.button": "{0} [{1}] pressed button {2}->{3}",
 
     "mute.thirty": "All t's are muted for the first 30 seconds",
     "mute.speak_quietly": "T's may now speak quietly",

--- a/src/Jail.cs
+++ b/src/Jail.cs
@@ -204,11 +204,12 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
 
     public override string ModuleName => "CS2 Jailbreak - destoer";
 
-    public override string ModuleVersion => "v0.2.2";
+    public override string ModuleVersion => "v1.2.2";
 
     public override void Load(bool hotReload)
     {
         global_ctx = this;
+        logs = new Logs(this); 
 
         register_commands();
         
@@ -222,7 +223,6 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
 
         AddTimer(Warden.LASER_TIME,warden.laser_tick,CSTimer.TimerFlags.REPEAT);
 
-        logs = new Logs(this); 
     }
 
     void stat_db_reload()

--- a/src/Jail.cs
+++ b/src/Jail.cs
@@ -204,7 +204,7 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
 
     public override string ModuleName => "CS2 Jailbreak - destoer";
 
-    public override string ModuleVersion => "v0.3.3";
+    public override string ModuleVersion => "v0.2.2";
 
     public override void Load(bool hotReload)
     {

--- a/src/Jail.cs
+++ b/src/Jail.cs
@@ -413,6 +413,7 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
         if(player != null && player.is_valid() && ent != null && ent.IsValid)
         {
             Lib.print_console_all($"{player.PlayerName} pressed button '{ent.Entity?.Name}' -> '{output?.Connections?.TargetDesc}'",true);
+            logs.AddLocalized("logs.format.button", player, ent.Entity?.Name ?? "Unlabeled", output?.Connections?.TargetDesc ?? "None");
         }
 
         return HookResult.Continue;

--- a/src/Jail.cs
+++ b/src/Jail.cs
@@ -204,7 +204,7 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
 
     public override string ModuleName => "CS2 Jailbreak - destoer";
 
-    public override string ModuleVersion => "v1.2.2";
+    public override string ModuleVersion => "v0.3.3";
 
     public override void Load(bool hotReload)
     {

--- a/src/Jail.cs
+++ b/src/Jail.cs
@@ -433,6 +433,7 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
         {
             lr.grenade_thrown(player);
             sd.grenade_thrown(player);
+            logs.AddLocalized(player, "logs.format.grenade", @event.Weapon); 
         }
 
         return HookResult.Continue;

--- a/src/Jail.cs
+++ b/src/Jail.cs
@@ -221,6 +221,8 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
         Console.WriteLine("Sucessfully started JB");
 
         AddTimer(Warden.LASER_TIME,warden.laser_tick,CSTimer.TimerFlags.REPEAT);
+
+        logs = new Logs(this); 
     }
 
     void stat_db_reload()
@@ -667,4 +669,5 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
     public static LastRequest lr = new LastRequest();
     public static SpecialDay sd = new SpecialDay();
     public static JailStats jail_stats = new JailStats();
+    public static Logs logs;
 }

--- a/src/Jail.cs
+++ b/src/Jail.cs
@@ -414,7 +414,7 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
         if(player != null && player.is_valid() && ent != null && ent.IsValid)
         {
             Lib.print_console_all($"{player.PlayerName} pressed button '{ent.Entity?.Name}' -> '{output?.Connections?.TargetDesc}'",true);
-            logs.AddLocalized("logs.format.button", player, ent.Entity?.Name ?? "Unlabeled", output?.Connections?.TargetDesc ?? "None");
+            logs.AddLocalized(player, "logs.format.button", ent.Entity?.Name ?? "Unlabeled", output?.Connections?.TargetDesc ?? "None");
         }
 
         return HookResult.Continue;

--- a/src/Jail.cs
+++ b/src/Jail.cs
@@ -204,7 +204,7 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
 
     public override string ModuleName => "CS2 Jailbreak - destoer";
 
-    public override string ModuleVersion => "v0.2.2";
+    public override string ModuleVersion => "v1.2.2";
 
     public override void Load(bool hotReload)
     {

--- a/src/Jail.cs
+++ b/src/Jail.cs
@@ -308,6 +308,7 @@ public class JailPlugin : BasePlugin, IPluginConfig<JailConfig>
         add_localized_cmd("sd.start_ff_cmd","start a ff sd",sd.sd_ff_cmd);
         add_localized_cmd("sd.cancel_cmd","cancel an sd",sd.cancel_sd_cmd);
 
+        add_localized_cmd("logs.logs_cmd", "show round logs", logs.LogsCommand);
         AddCommandListener("jointeam",join_team);
 
         // debug 

--- a/src/Warden/JailPlayer.cs
+++ b/src/Warden/JailPlayer.cs
@@ -320,11 +320,11 @@ public class JailPlayer
         string localKey = health > 0 ? "logs.format.damage" : "logs.format.kill";
         if (isWorld)
         {
-            JailPlugin.logs.AddLocalized(localKey + "_self", player, damage);
+            JailPlugin.logs.AddLocalized(player, localKey + "_self", damage);
         }
         else
         {
-            JailPlugin.logs.AddLocalized(localKey, attacker!, player, damage);
+            JailPlugin.logs.AddLocalized(player, localKey, attacker!, damage);
         }
 
         if (isWorld)

--- a/src/Warden/JailPlayer.cs
+++ b/src/Warden/JailPlayer.cs
@@ -12,6 +12,7 @@ using CounterStrikeSharp.API.Modules.Utils;
 using CounterStrikeSharp.API.Modules.Entities.Constants;
 using System.Drawing;
 using Microsoft.Data.Sqlite;
+using McMaster.NETCore.Plugins;
 
 
 public class JailPlayer
@@ -40,7 +41,7 @@ public class JailPlayer
 
 
                 // start populating our fields
-                foreach(var cmd in col_cmd)
+                foreach (var cmd in col_cmd)
                 {
                     var col = connection.CreateCommand();
                     col.CommandText = cmd;
@@ -52,19 +53,19 @@ public class JailPlayer
                         col.ExecuteNonQuery();
                     }
 
-                    catch {}
+                    catch { }
                 }
             }
         }
 
         // Actually print these, creation should not fail
-        catch(Exception ex)
+        catch (Exception ex)
         {
             Console.WriteLine(ex.ToString());
         }
     }
 
-    async Task update_player_db(String steam_id,String name,String value)
+    async Task update_player_db(String steam_id, String name, String value)
     {
         try
         {
@@ -75,12 +76,12 @@ public class JailPlayer
                 // modify one of the setting fields
                 using var update = connection.CreateCommand();
                 update.CommandText = $"UPDATE config SET {name} = '{value}' WHERE steam_id = @steam_id";
-                update.Parameters.AddWithValue("@steam_id",steam_id);
+                update.Parameters.AddWithValue("@steam_id", steam_id);
 
                 await update.ExecuteNonQueryAsync();
             }
-        } 
-        
+        }
+
         catch (Exception ex)
         {
             Console.WriteLine(ex.ToString());
@@ -91,23 +92,23 @@ public class JailPlayer
     {
         using (var connection = new SqliteConnection("Data Source=destoer_config.sqlite"))
         {
-            try 
+            try
             {
                 await connection.OpenAsync();
 
                 // add a new steam id
                 using var insert_player = connection.CreateCommand();
                 insert_player.CommandText = "INSERT OR IGNORE INTO config (steam_id) VALUES (@steam_id)";
-                insert_player.Parameters.AddWithValue("@steam_id",steam_id);
+                insert_player.Parameters.AddWithValue("@steam_id", steam_id);
 
                 await insert_player.ExecuteNonQueryAsync();
-            } 
-            
+            }
+
             catch (Exception ex)
             {
                 Console.WriteLine(ex.ToString());
             }
-        }    
+        }
     }
 
     async Task load_player_db(String steam_id)
@@ -123,14 +124,14 @@ public class JailPlayer
 
                 // query steamid
                 query_steam_id.CommandText = "SELECT * FROM config WHERE steam_id = @steam_id";
-                query_steam_id.Parameters.AddWithValue("@steam_id",steam_id);
+                query_steam_id.Parameters.AddWithValue("@steam_id", steam_id);
 
                 using var reader = await query_steam_id.ExecuteReaderAsync();
-                
-                if(reader.Read())
+
+                if (reader.Read())
                 {
                     // just override this
-                    laser_colour =  Lib.LASER_CONFIG_MAP[(String)reader["laser_colour"]];
+                    laser_colour = Lib.LASER_CONFIG_MAP[(String)reader["laser_colour"]];
                     marker_colour = Lib.LASER_CONFIG_MAP[(String)reader["marker_colour"]];
                     ct_gun = (String)reader["ct_gun"];
 
@@ -156,14 +157,14 @@ public class JailPlayer
 
     public void load_player(CCSPlayerController? player)
     {
-        if(player == null || !player.is_valid())
+        if (player == null || !player.is_valid())
         {
             return;
         }
 
         // The database has allready been read before
         // there is not need to do it again
-        if(cached)
+        if (cached)
         {
             return;
         }
@@ -179,7 +180,7 @@ public class JailPlayer
 
     public void update_player(CCSPlayerController? player, String name, String value)
     {
-        if(player == null || !player.is_valid())
+        if (player == null || !player.is_valid())
         {
             return;
         }
@@ -189,36 +190,36 @@ public class JailPlayer
         // make sure this doesn't block the main thread
         Task.Run(async () =>
         {
-            await update_player_db(steam_id,name,value);
+            await update_player_db(steam_id, name, value);
         });
     }
 
-    public void set_laser(CCSPlayerController? player,String value)
+    public void set_laser(CCSPlayerController? player, String value)
     {
-        if(player == null || !player.is_valid())
+        if (player == null || !player.is_valid())
         {
             return;
         }
 
-        player.announce(Warden.WARDEN_PREFIX,$"Laser colour set to {value}");
+        player.announce(Warden.WARDEN_PREFIX, $"Laser colour set to {value}");
         laser_colour = Lib.LASER_CONFIG_MAP[value];
 
         // save back to the db too
-        update_player(player,"laser_colour",value);
+        update_player(player, "laser_colour", value);
     }
 
-    public void set_marker(CCSPlayerController? player,String value)
+    public void set_marker(CCSPlayerController? player, String value)
     {
-        if(player == null || !player.is_valid())
+        if (player == null || !player.is_valid())
         {
             return;
         }
 
-        player.announce(Warden.WARDEN_PREFIX,$"Marker colour set to {value}");
+        player.announce(Warden.WARDEN_PREFIX, $"Marker colour set to {value}");
         marker_colour = Lib.LASER_CONFIG_MAP[value];
 
         // save back to the db too
-        update_player(player,"marker_colour",value);
+        update_player(player, "marker_colour", value);
     }
 
     public void purge_round()
@@ -239,71 +240,71 @@ public class JailPlayer
     public void set_rebel(CCSPlayerController? player)
     {
         // allready a rebel don't care
-        if(is_rebel)
+        if (is_rebel)
         {
             return;
         }
 
-        if(JailPlugin.event_active())
+        if (JailPlugin.event_active())
         {
             return;
         }
 
         // ignore if they are in lr
-        if(JailPlugin.lr.in_lr(player))
+        if (JailPlugin.lr.in_lr(player))
         {
             return;
         }
-        
+
         // dont care if player is invalid
-        if(!player.is_valid() || player == null)
+        if (!player.is_valid() || player == null)
         {
             return;
         }
 
         // on T with no warday or sd active
-        if(player.TeamNum == Lib.TEAM_T)
+        if (player.TeamNum == Lib.TEAM_T)
         {
-            if(config.colour_rebel)
+            if (config.colour_rebel)
             {
-                Lib.announce(REBEL_PREFIX,$"{player.PlayerName} is a rebel");
+                Lib.announce(REBEL_PREFIX, $"{player.PlayerName} is a rebel");
                 player.set_colour(Lib.RED);
             }
             is_rebel = true;
         }
     }
 
-    public void rebel_death(CCSPlayerController? player,CCSPlayerController? killer)
+    public void rebel_death(CCSPlayerController? player, CCSPlayerController? killer)
     {
         // event active dont care
-        if(JailPlugin.event_active())
+        if (JailPlugin.event_active())
         {
             return;
         }
 
         // players aernt valid dont care
-        if(killer == null || player == null || !player.is_valid() || !killer.is_valid())
+        if (killer == null || player == null || !player.is_valid() || !killer.is_valid())
         {
             return;
         }
 
         // print death if player is rebel and killer on CT
-        if(is_rebel && killer.TeamNum == Lib.TEAM_CT)
+        if (is_rebel && killer.TeamNum == Lib.TEAM_CT)
         {
             Lib.log($"rebel {player.PlayerName} killed by {killer.PlayerName}");
-            Lib.localise_announce(REBEL_PREFIX,"rebel.kill",killer.PlayerName,player.PlayerName);
+            Lib.localise_announce(REBEL_PREFIX, "rebel.kill", killer.PlayerName, player.PlayerName);
         }
     }
 
     public void rebel_weapon_fire(CCSPlayerController? player, String weapon)
     {
-        if(config.rebel_requirehit)
+        if (config.rebel_requirehit)
         {
             return;
         }
-        
+
         // ignore weapons players are meant to have
-        if(!weapon.Contains("knife") && !weapon.Contains("c4"))
+        if (!weapon.Contains("knife") && !weapon.Contains("c4"))
         {
             set_rebel(player);
         }
@@ -311,19 +312,34 @@ public class JailPlayer
 
     public void player_hurt(CCSPlayerController? player, CCSPlayerController? attacker, int health, int damage)
     {
-        if(player == null || attacker == null || !player.is_valid() || !attacker.is_valid())
+        if (player == null || !player.is_valid())
+            return;
+
+        bool isWorld = attacker == null || !attacker.is_valid();
+
+        string localKey = health > 0 ? "logs.format.damage" : "logs.format.kill";
+        if (isWorld)
+        {
+            JailPlugin.logs.AddLocalized(localKey + "_self", player, damage);
+        }
+        else
+        {
+            JailPlugin.logs.AddLocalized(localKey, attacker!, player, damage);
+        }
+
+        if (isWorld)
         {
             return;
         }
 
         // ct hit by T they are a rebel
-        if(player.is_ct() && attacker.is_t())
+        if (player.is_ct() && attacker.is_t())
         {
             set_rebel(attacker);
         }
 
         // log any ct damage
-        else if(attacker.is_ct())
+        else if (attacker.is_ct())
         {
             //Lib.print_console_all($"CT {attacker.PlayerName} hit {player.PlayerName} for {damage}");
         }

--- a/src/Warden/JailPlayer.cs
+++ b/src/Warden/JailPlayer.cs
@@ -324,7 +324,7 @@ public class JailPlayer
         }
         else
         {
-            JailPlugin.logs.AddLocalized(player, localKey, attacker!, damage);
+            JailPlugin.logs.AddLocalized(player, attacker!, localKey, damage);
         }
 
         if (isWorld)

--- a/src/Warden/Logs.cs
+++ b/src/Warden/Logs.cs
@@ -1,5 +1,6 @@
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Utils;
 
 public class Logs
 {
@@ -54,5 +55,31 @@ public class Logs
     public void AddLocalized(string key, params object[] args)
     {
         Add(plugin.Localizer[key, args]);
+    }
+
+    public void AddLocalized(CCSPlayerController source, string key, params object[] args)
+    {
+        Add(plugin.Localizer[key, source.PlayerName, GetPlayerRole(source), args]);
+    }
+
+    public void AddLocalized(CCSPlayerController source, CCSPlayerController target, string key, params object[] args)
+    {
+        Add(plugin.Localizer[key, source.PlayerName, GetPlayerRole(source), target.PlayerName, GetPlayerRole(target), args]);
+    }
+
+
+    public String GetPlayerRole(CCSPlayerController player)
+    {
+        switch ((CsTeam)player.TeamNum)
+        {
+            case CsTeam.Spectator:
+                return plugin.Localizer["role.spectator"];
+            case CsTeam.CounterTerrorist:
+                return plugin.Localizer[JailPlugin.warden.is_warden(player) ? "role.warden" : "role.guard"];
+            case CsTeam.Terrorist:
+                return plugin.Localizer[JailPlugin.warden.jail_players[player.Slot].is_rebel ? "role.rebel" : "role_prisoner"];
+            default:
+                return plugin.Localizer["role.unknown"];
+        }
     }
 }

--- a/src/Warden/Logs.cs
+++ b/src/Warden/Logs.cs
@@ -27,6 +27,7 @@ public class Logs
             if (!player.IsValid || player.IsBot || player.IsHLTV) continue;
             printLogs(player);
         }
+        logs.Clear();
         return HookResult.Continue;
     }
 
@@ -54,14 +55,13 @@ public class Logs
 
     private HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
     {
-        logs.Clear();
         roundStart = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         return HookResult.Continue;
     }
 
     public void Add(string log)
     {
-        string format = $"[{DateTimeOffset.UtcNow.ToUnixTimeSeconds() - roundStart}:mm\\:ss] {log}";
+        string format = $"[{DateTimeOffset.UtcNow.ToUnixTimeSeconds() - roundStart:mm\\:ss}] {log}";
         logs.Add(format);
     }
 
@@ -72,12 +72,14 @@ public class Logs
 
     public void AddLocalized(CCSPlayerController source, string key, params object[] args)
     {
-        Add(plugin.Localizer[key, source.PlayerName, GetPlayerRole(source), args]);
+        args = args.Prepend(GetPlayerRole(source)).Prepend(source.PlayerName).ToArray();
+        Add(plugin.Localizer[key, args]);
     }
 
     public void AddLocalized(CCSPlayerController source, CCSPlayerController target, string key, params object[] args)
     {
-        Add(plugin.Localizer[key, source.PlayerName, GetPlayerRole(source), target.PlayerName, GetPlayerRole(target), args]);
+        args = args.Prepend(GetPlayerRole(target)).Prepend(target.PlayerName).Prepend(GetPlayerRole(source)).Prepend(source.PlayerName).ToArray();
+        Add(plugin.Localizer[key, args]);
     }
 
 

--- a/src/Warden/Logs.cs
+++ b/src/Warden/Logs.cs
@@ -41,7 +41,6 @@ public class Logs
     private void printLogs(Delegate printFunction)
     {
         printFunction.DynamicInvoke("********************************");
-        printFunction.DynamicInvoke("********************************");
         printFunction.DynamicInvoke("***** BEGIN JAILBREAK LOGS *****");
         printFunction.DynamicInvoke("********************************");
         foreach (string log in logs)

--- a/src/Warden/Logs.cs
+++ b/src/Warden/Logs.cs
@@ -63,7 +63,7 @@ public class Logs
     public void Add(string log)
     {
         string format = $"[{DateTimeOffset.UtcNow.ToUnixTimeSeconds() - roundStart}:mm\\:ss] {log}";
-        logs.Add(log);
+        logs.Add(format);
     }
 
     public void AddLocalized(string key, params object[] args)

--- a/src/Warden/Logs.cs
+++ b/src/Warden/Logs.cs
@@ -1,5 +1,6 @@
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Modules.Utils;
 
 public class Logs
@@ -15,6 +16,10 @@ public class Logs
         plugin.RegisterEventHandler<EventRoundEnd>(OnRoundEnd);
     }
 
+    public void LogsCommand(CCSPlayerController? executor, CommandInfo info) {
+        printLogs(executor);
+    }
+
     private HookResult OnRoundEnd(EventRoundEnd @event, GameEventInfo info)
     {
         foreach (CCSPlayerController player in Utilities.GetPlayers())
@@ -25,18 +30,27 @@ public class Logs
         return HookResult.Continue;
     }
 
-    private void printLogs(CCSPlayerController player)
+    private void printLogs(CCSPlayerController? player) {
+        if(player == null) {
+            printLogs(Server.PrintToConsole);
+        } else {
+            printLogs(player.PrintToConsole);
+        }
+    }
+
+    private void printLogs(Delegate printFunction)
     {
-        player.PrintToConsole("********************************");
-        player.PrintToConsole("***** BEGIN JAILBREAK LOGS *****");
-        player.PrintToConsole("********************************");
+        printFunction.DynamicInvoke("********************************");
+        printFunction.DynamicInvoke("********************************");
+        printFunction.DynamicInvoke("***** BEGIN JAILBREAK LOGS *****");
+        printFunction.DynamicInvoke("********************************");
         foreach (string log in logs)
         {
-            player.PrintToConsole(log);
+            printFunction.DynamicInvoke(log);
         }
-        player.PrintToConsole("********************************");
-        player.PrintToConsole("****** END JAILBREAK LOGS ******");
-        player.PrintToConsole("********************************");
+        printFunction.DynamicInvoke("********************************");
+        printFunction.DynamicInvoke("****** END JAILBREAK LOGS ******");
+        printFunction.DynamicInvoke("********************************");
     }
 
     private HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)

--- a/src/Warden/Logs.cs
+++ b/src/Warden/Logs.cs
@@ -16,7 +16,8 @@ public class Logs
         plugin.RegisterEventHandler<EventRoundEnd>(OnRoundEnd);
     }
 
-    public void LogsCommand(CCSPlayerController? executor, CommandInfo info) {
+    public void LogsCommand(CCSPlayerController? executor, CommandInfo info)
+    {
         printLogs(executor);
     }
 
@@ -31,10 +32,14 @@ public class Logs
         return HookResult.Continue;
     }
 
-    private void printLogs(CCSPlayerController? player) {
-        if(player == null) {
+    private void printLogs(CCSPlayerController? player)
+    {
+        if (player == null)
+        {
             printLogs(Server.PrintToConsole);
-        } else {
+        }
+        else
+        {
             printLogs(player.PrintToConsole);
         }
     }
@@ -61,7 +66,8 @@ public class Logs
 
     public void Add(string log)
     {
-        string format = $"[{DateTimeOffset.UtcNow.ToUnixTimeSeconds() - roundStart:mm\\:ss}] {log}";
+        TimeSpan span = TimeSpan.FromSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds() - roundStart);
+        string format = $"[{span:mm':'ss}] {log}";
         logs.Add(format);
     }
 

--- a/src/Warden/Logs.cs
+++ b/src/Warden/Logs.cs
@@ -1,0 +1,58 @@
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+
+public class Logs
+{
+    private readonly List<string> logs = new List<string>();
+    private readonly BasePlugin plugin;
+    private long roundStart = -1;
+
+    public Logs(BasePlugin plugin)
+    {
+        this.plugin = plugin;
+        plugin.RegisterEventHandler<EventRoundStart>(OnRoundStart);
+        plugin.RegisterEventHandler<EventRoundEnd>(OnRoundEnd);
+    }
+
+    private HookResult OnRoundEnd(EventRoundEnd @event, GameEventInfo info)
+    {
+        foreach (CCSPlayerController player in Utilities.GetPlayers())
+        {
+            if (!player.IsValid || player.IsBot || player.IsHLTV) continue;
+            printLogs(player);
+        }
+        return HookResult.Continue;
+    }
+
+    private void printLogs(CCSPlayerController player)
+    {
+        player.PrintToConsole("********************************");
+        player.PrintToConsole("***** BEGIN JAILBREAK LOGS *****");
+        player.PrintToConsole("********************************");
+        foreach (string log in logs)
+        {
+            player.PrintToConsole(log);
+        }
+        player.PrintToConsole("********************************");
+        player.PrintToConsole("****** END JAILBREAK LOGS ******");
+        player.PrintToConsole("********************************");
+    }
+
+    private HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
+    {
+        logs.Clear();
+        roundStart = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        return HookResult.Continue;
+    }
+
+    public void Add(string log)
+    {
+        string format = $"[{DateTimeOffset.UtcNow.ToUnixTimeSeconds() - roundStart}:mm\\:ss] {log}";
+        logs.Add(log);
+    }
+
+    public void AddLocalized(string key, params object[] args)
+    {
+        Add(plugin.Localizer[key, args]);
+    }
+}

--- a/src/Warden/Warden.cs
+++ b/src/Warden/Warden.cs
@@ -59,6 +59,8 @@ public partial class Warden
 
         // change player color!
         player.set_colour(Color.FromArgb(255, 0, 0, 255));
+
+        JailPlugin.logs.Add($"{player.PlayerName} is now the warden");
     }
 
     public bool is_warden(CCSPlayerController? player)

--- a/src/Warden/Warden.cs
+++ b/src/Warden/Warden.cs
@@ -60,7 +60,7 @@ public partial class Warden
         // change player color!
         player.set_colour(Color.FromArgb(255, 0, 0, 255));
 
-        JailPlugin.logs.Add($"{player.PlayerName} is now the warden");
+        JailPlugin.logs.AddLocalized("warden.took_warden", player.PlayerName);
     }
 
     public bool is_warden(CCSPlayerController? player)
@@ -84,6 +84,7 @@ public partial class Warden
 
             player.set_colour(Color.FromArgb(255, 255, 255, 255));
             Lib.localise_announce(WARDEN_PREFIX,"warden.removed",player.PlayerName);
+            JailPlugin.logs.AddLocalized("warden.removed", player.PlayerName);
         }
 
         remove_warden_internal();
@@ -646,7 +647,7 @@ public partial class Warden
 
     public JailConfig config = new JailConfig();
 
-    JailPlayer[] jail_players = new JailPlayer[64];
+    public JailPlayer[] jail_players = new JailPlayer[64];
 
     public Warday warday = new Warday();
     public Block block = new Block();


### PR DESCRIPTION
While not perfectly fleshed out, this MR adds the base for a basic logs system.

Kills, damage, wardens, and buttons are all logged and shown to all players at the end of the round.
A !logs command is also added for all players (though I recommend locking this behind a permission in the future).
Localization needs to be added in the header, too lazy atm.